### PR TITLE
Use one bot per worker to send images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 ## Project
 
-config.json
+.env
+config.yaml
 
+# Rina
+run.bat
+run2.bat
 
 ## Editors
 
@@ -134,5 +138,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-run.bat
-run2.bat

--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,15 @@ The bot can either be run with docker-compose or using another process manager, 
 First you have to create a config file with credentials, you can simply copy the ``example-config.json`` and
 edit it with your own values, then save it as ``config.json``.
 
+Afterwards you'll want to adjust the ``WORKER_COUNT`` environment variable, if using docker you can copy the
+``example.env`` file, edit it and save it as ``.env``.
+
 To run the bot with docker see these steps:
 
 .. code-block :: bash
 
     docker build -t blurplefy .
 
-    # You can adjust how many workers you want to run here
     docker-compose up --scale workers=2
 
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 
-import json
-
 import aioredis
 from discord.ext import commands
+
+import ruamel.yaml
 
 
 class Bot(commands.Bot):
     def __init__(self, config, **kwargs):
         super().__init__(
-            command_prefix=config['prefix'],
-            owner_id=config.get('owner_id'),
+            command_prefix=config['bot']['prefix'],
+            owner_id=config['bot'].get('owner_id'),
             **kwargs,
         )
 
@@ -24,18 +24,18 @@ class Bot(commands.Bot):
             self.load_extension(name)
 
     @classmethod
-    def with_config(cls, path='config.json'):
+    def with_config(cls, path='config.yaml'):
         """Create a bot instance with a Config."""
 
         with open(path) as f:
-            data = json.load(f)
+            data = ruamel.yaml.safe_load(f)
 
         return cls(data)
 
     async def start(self, *args, **kwargs):
-        self.redis = await aioredis.create_redis_pool(self.config['redis'])
+        self.redis = await aioredis.create_redis_pool(**self.config['redis'])
 
         await super().start(*args, **kwargs)
 
     def run(self):
-        super().run(self.config['token'])
+        super().run(self.config['bot']['token'])

--- a/bot/cogs/blurple/cog.py
+++ b/bot/cogs/blurple/cog.py
@@ -11,7 +11,7 @@ from bot import Cog
 
 
 def _make_color_command(name, modifier, **kwargs):
-    @commands.command(name, help=f'{name.title()}fy an image.', **kwargs)
+    @commands.command(name, help=f'{name.title()} an image.', **kwargs)
     async def command(self, ctx, *, who: typing.Union[discord.Member, discord.PartialEmoji, LinkConverter] = None):
 
         if ctx.message.attachments:
@@ -31,7 +31,7 @@ def _make_color_command(name, modifier, **kwargs):
         await ctx.bot.redis.rpush('blurple:queue', json.dumps(data))
 
         # Signal that the request has been queued
-        await ctx.message.add_reaction('\N{FLOPPY DISK}')
+        await ctx.message.add_reaction(self.bot.config['queue_emoji'])
 
     return command
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
       - redis
     volumes:
       - ./:/app
+    environment:
+      - WORKER_COUNT=${WORKER_COUNT}
 
   redis:
     image: redis:5-alpine

--- a/example-config.json
+++ b/example-config.json
@@ -1,6 +1,0 @@
-{
-  "token": "secret",
-  "prefix": "~!?",
-  "owner_id": 0,
-  "redis": ["redis", 6379]
-}

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,0 +1,17 @@
+queue_emoji: 🤸
+
+bot:
+  prefix: !
+  owner_id: 69198249432449024
+
+  token: beep.boop.secret
+
+workers:
+  - first.worker.token
+  - second.worker.token
+  # Add as many as needed
+
+redis:
+  address:
+    - redis
+    - 6379

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aioredis
-discord.py @ git+https://github.com/Rapptz/discord.py@rewrite
+discord.py
 jishaku
 pillow
+ruamel.yaml

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
 
 import asyncio
+import base64
 import json
 import logging
+import os
 import signal
+import sys
 
 import aiohttp
 import aioredis
 import discord.http
+import ruamel.yaml
 
 from .magic import convert_image
 
@@ -15,50 +19,97 @@ from .magic import convert_image
 log = logging.getLogger(__name__)
 
 
+WORKER_COUNT = int(os.environ.get('WORKER_COUNT', '1'))
+
+
+# Please ignore this ugliness
+async def _yield_forever():
+    while True:
+        await asyncio.sleep(1)
+
+
 class Worker:
     def __init__(self, config):
         self.config = config
 
+        self.http = None
         self.redis = None
+
+        self.token = None
+        self.worker_id = None
+
+        self._bot_user_id = int(base64.b64decode(self.config['bot']['token'].split('.', 1)[0]))
+
         self.loop = asyncio.get_event_loop()
 
-        self.http = None
-
-
     @classmethod
-    def with_config(cls, path='config.json'):
+    def with_config(cls, path='config.yaml'):
         """Create a bot instance with a Config."""
 
         with open(path) as f:
-            data = json.load(f)
+            data = ruamel.yaml.safe_load(f)
 
         return cls(data)
+
+    async def start(self):
+        self.redis = await aioredis.create_redis_pool(**self.config['redis'])
+
+        await self.claim_token()
+        self._claim_task = self.loop.create_task(self._keep_claim())
+
+        # We're using discord.py's HTTP class for rate limit handling
+        # This is not intended to be used so there's no pretty way of creating it
+        self.http = http = discord.http.HTTPClient()
+        http._token(self.token)
+        http._HTTPClient__session = aiohttp.ClientSession()
+
+        self.loop.create_task(self.run_jobs())
+
+        await _yield_forever()
 
     def run(self):
         loop = self.loop
 
-        loop.create_task(self.run_jobs())
+        loop.create_task(self.start())
 
         try:
-            loop.add_signal_handler(signal.SIGINT, lambda x: loop.close)
-            loop.add_signal_handler(signal.SIGTERM, lambda x: loop.close)
+            loop.add_signal_handler(signal.SIGINT, loop.stop)
+            loop.add_signal_handler(signal.SIGTERM, loop.stop)
         except RuntimeError:  # Windows
             pass
 
         try:
             loop.run_forever()
         except KeyboardInterrupt:
-            loop.close()
+            loop.stop()
+
+    async def claim_token(self):
+        # We have a token per active worker
+        # As we don't know which worker we are we simply claim a token by setting a key in redis
+        # If it's set we can assume it to be currently used (unless the worker crashed - but it'll expire)
+        # Should we not find a free token we'll simply wait for 10 seconds and try again
+
+        while self.token is None:
+            for worker_id in range(WORKER_COUNT):
+                if await self.redis.execute('SET', f'blurple:worker:{worker_id}', ':ablobwave:', 'NX', 'EX', '30'):
+                    self.worker_id = worker_id
+                    self.token = self.config['workers'][worker_id]
+
+            if self.token is None:
+                log.warning('Failed to claim worker ID, retrying in 10 seconds ..')
+                await asyncio.sleep(10)
+
+    async def _keep_claim(self):
+        while not self.loop.is_closed():
+            try:
+                with await self.redis as conn:
+                    await conn.set(f'blurple:worker:{self.worker_id}', ':ablobwavereverse:', expire=30)
+            except (aioredis.ConnectionClosedError, aioredis.ProtocolError, aioredis.ReplyError, TypeError):
+                log.exception('Failed to continue worker ID claim, retrying in 10 seconds ..')
+
+            await asyncio.sleep(10)
 
     async def run_jobs(self):
-        self.redis = await aioredis.create_redis(self.config['redis'])
-
-        # We're using discord.py's HTTP class for rate limit handling
-        # This is not intended to be used so there's no pretty way of creating it
-        self.http = http = discord.http.HTTPClient()
-        http._token(self.config['token'])
-        http._HTTPClient__session = aiohttp.ClientSession()
-
         while self.loop.is_running():
             _, data = await self.redis.blpop('blurple:queue')
 
@@ -96,11 +147,15 @@ class Worker:
         try:
             msg = f'Here is your image <@!{user_id}>!'
             await self.http.send_files(channel_id, content=msg, files=(result,))
-            await self.http.remove_own_reaction(message_id, channel_id, '\N{FLOPPY DISK}')
         except discord.HTTPException:
             await self._send_error(
                 f'I couldn\'t upload your image to Discord, it may be too big <@!{user_id}>!', channel_id
             )
+
+        try:
+            await self.http.remove_reaction(message_id, channel_id, self.config['queue_emoji'], self._bot_user_id)
+        except discord.HTTPException:
+            pass
 
     async def _send_error(self, message, channel_id):
         try:


### PR DESCRIPTION
As I've discussed with @Zeboto on Discord, this PR allows (requires) each worker to use it's own bot account to reply to requests.

I've also changed the config to be a yaml instead of json file to be easier to manipulate for humans.