### PR TITLE
Some Dockerfile changes and README fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN pip install -r requirements.txt
 
 FROM python:3.7-alpine
 RUN apk add --no-cache jpeg-dev libwebp libwebp-dev
-WORKDIR /blurple
+WORKDIR /app
 COPY --from=requirements /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
 RUN adduser -D -h /app -s /bin/sh -u 1000 blurple
 COPY --chown=1000 . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-FROM python:3.7
-
-WORKDIR /app
-ADD requirements.txt /app
-
+FROM python:3.7-alpine AS requirements
+ADD requirements.txt .
+RUN apk add --no-cache libffi-dev gcc zlib-dev jpeg-dev freetype-dev libwebp libwebp-dev musl-dev
 RUN pip install -r requirements.txt
+
+FROM python:3.7-alpine
+RUN apk add --no-cache jpeg-dev libwebp libwebp-dev
+WORKDIR /app
+COPY --from=requirements /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+RUN adduser -D -h /app -s /bin/sh -u 1000 blurple
+COPY --chown=1000 . .
+USER blurple

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-FROM python:3.7
-
-WORKDIR /app
-ADD requirements.txt /app
-
+FROM python:3.7-alpine AS requirements
+ADD requirements.txt .
+RUN apk add --no-cache libffi-dev gcc zlib-dev jpeg-dev freetype-dev libwebp libwebp-dev musl-dev
 RUN pip install -r requirements.txt
+
+FROM python:3.7-alpine
+RUN apk add --no-cache jpeg-dev libwebp libwebp-dev
+WORKDIR /blurple
+COPY --from=requirements /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+RUN adduser -D -h /app -s /bin/sh -u 1000 blurple
+COPY --chown=1000 . .
+USER blurple

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-=========
 Blurplefy
 =========
 
@@ -18,21 +17,19 @@ Afterwards you'll want to adjust the ``WORKER_COUNT`` environment variable, if u
 
 To run the bot with docker see these steps:
 
-.. code-block :: bash
+```bash
+docker-compose up --scale workers=2
+```
 
-    docker-compose up --scale workers=2
-
-
-To run the bot without docker you will need to install and run `Redis <https://redis.io>`_ (see
-`here <https://redislabs.com/blog/redis-on-windows-10/>`_ for Windows 10 instructions) as well as
+To run the bot without docker you will need to install and run [Redis](https://redis.io) (see
+[here](https://redislabs.com/blog/redis-on-windows-10/) for Windows 10 instructions) as well as
 install all the Python requirements using ``pip install -Ur requirements.txt``.
 
 Running the bot and worker can then be done from the root directory of this repository:
 
-.. code-block :: bash
+```
+python -m bot
 
-    python -m bot
-
-    python -m worker
-
+python -m worker
+```
 And that's it! Have fun with the bot.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-=========
 Blurplefy
 =========
 
@@ -10,31 +9,27 @@ Running
 
 The bot can either be run with docker-compose or using another process manager, the steps are explained below:
 
-First you have to create a config file with credentials, you can simply copy the ``example-config.json`` and
-edit it with your own values, then save it as ``config.json``.
+First you have to create a config file with credentials, you can simply copy the ``example-config.yaml`` and
+edit it with your own values, then save it as ``config.yaml``.
 
 Afterwards you'll want to adjust the ``WORKER_COUNT`` environment variable, if using docker you can copy the
 ``example.env`` file, edit it and save it as ``.env``.
 
 To run the bot with docker see these steps:
 
-.. code-block :: bash
+```bash
+docker-compose up --scale workers=2
+```
 
-    docker build -t blurplefy .
-
-    docker-compose up --scale workers=2
-
-
-To run the bot without docker you will need to install and run `Redis <https://redis.io>`_ (see
-`here <https://redislabs.com/blog/redis-on-windows-10/>`_ for Windows 10 instructions) as well as
+To run the bot without docker you will need to install and run [Redis](https://redis.io) (see
+[here](https://redislabs.com/blog/redis-on-windows-10/) for Windows 10 instructions) as well as
 install all the Python requirements using ``pip install -Ur requirements.txt``.
 
 Running the bot and worker can then be done from the root directory of this repository:
 
-.. code-block :: bash
+```
+python -m bot
 
-    python -m bot
-
-    python -m worker
-
+python -m worker
+```
 And that's it! Have fun with the bot.

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Running
 
 The bot can either be run with docker-compose or using another process manager, the steps are explained below:
 
-First you have to create a config file with credentials, you can simply copy the ``example-config.json`` and
-edit it with your own values, then save it as ``config.json``.
+First you have to create a config file with credentials, you can simply copy the ``example-config.yaml`` and
+edit it with your own values, then save it as ``config.yaml``.
 
 Afterwards you'll want to adjust the ``WORKER_COUNT`` environment variable, if using docker you can copy the
 ``example.env`` file, edit it and save it as ``.env``.
@@ -19,8 +19,6 @@ Afterwards you'll want to adjust the ``WORKER_COUNT`` environment variable, if u
 To run the bot with docker see these steps:
 
 .. code-block :: bash
-
-    docker build -t blurplefy .
 
     docker-compose up --scale workers=2
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   bot:
-    image: blurplefy
+    build: .
     command: python -m bot
     restart: unless-stopped
     depends_on:
@@ -13,7 +13,7 @@ services:
       - JISHAKU_HIDE=true
 
   worker:
-    image: blurplefy
+    build: .
     command: python -m worker
     restart: unless-stopped
     depends_on:

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,7 +1,15 @@
+# You will need to use a custom emoji here for when the bot is processing the image.
+# Get rid of the "a" if you are not using an animated emoji
 queue_emoji: a:loading:572202235342225418
 
+# This will be the guild where the bot will be serving blurple images.
 project_blurple_guild: 559341262302347314
 
+# Roles for when you have rolled for a team (either dark or light)
+# To set this up:
+# 1. Create 5 roles
+# 2. Make them mentionable temporarily
+# 3. Grab their ID's (put a \ before the @ when mentioning the role.)
 pending_blurple_light_role: 574854165415591957
 pending_blurple_dark_role: 574854043806072842
 
@@ -10,22 +18,29 @@ blurple_dark_role: 573651772812558337
 
 blacklist_role: 574109557425438730
 
+# You will need to react :one: and :two: to the message in order for this to work properly
+# On the message itself, mention that users will need to react in order to set the default !blurplefy mode
+# :one: being dark, :two: being light
 blurplefier_reaction_channel: 571144782202535956
 blurplefier_reaction_message: 572841925019959314
 
+# This will be the icon set at the bottom of all of the embeds
 footer_thumbnail_url: https://cdn.discordapp.com/emojis/412788702897766401.png?v=1
 
 bot:
-  prefix: !
+  prefix: "!"
   owner_id: 248245568004947969
 
+  # This can be obtained at https://discordapp.com/developers/applications/
   token: beep.boop.secret
 
+# The token(s) here will be the same as the bot token above
 workers:
   - first.worker.token
   - second.worker.token
   # Add as many as needed
 
+# Leave this alone since this is already configured for docker. (Unless you are setting it up on Windows, change the address)
 redis:
   address:
     - redis

--- a/example.env
+++ b/example.env
@@ -1,0 +1,1 @@
+WORKER_COUNT=2


### PR DESCRIPTION
I have made some changes in the Dockerfile and Docker-Compose files that would save a lot of space (964 MB down to 121 MB) and that you should not build an image before running `docker-compose up`. I even added some comments in the example config that would make it easier for one to self-host the bot themselves. And lastly, fix up the README a bit.